### PR TITLE
Set build-id to none

### DIFF
--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
         # List C/C++ source files with relative paths to this CMakeLists.txt.
         pathwrapper.cpp)
 
+add_link_options("-Wl,--build-id=none")
+
 # Specifies libraries CMake should link to your target library. You
 # can link libraries from various origins, such as libraries defined in this
 # build script, prebuilt third-party libraries, or Android system libraries.

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -24,11 +24,10 @@ project("flutter-saf")
 # System.loadLibrary() and pass the name of the library defined here;
 # for GameActivity/NativeActivity derived applications, the same library name must be
 # used in the AndroidManifest.xml file.
+add_link_options("-Wl,--build-id=none")
 add_library(${CMAKE_PROJECT_NAME} SHARED
         # List C/C++ source files with relative paths to this CMakeLists.txt.
         pathwrapper.cpp)
-
-add_link_options("-Wl,--build-id=none")
 
 # Specifies libraries CMake should link to your target library. You
 # can link libraries from various origins, such as libraries defined in this


### PR DESCRIPTION
@pkuislm Hi. I'm trying to complete Reproducible Builds of F-Droid for [venera](https://github.com/venera-app/venera), a flutter app that depends on your library.

> On different build machines, different NDK paths and different paths to the project (and thus to its jni directory) are used. This leads to different paths to the source files in debug symbols, causing the linker to generate a different build-id, which is preserved after stripping.

> One possible solution is passing --build-id=none to the linker which will disable build-id generation completely.

https://f-droid.org/docs/Reproducible_Builds/#ndk-build-id

I'm not familiar with C or Rust at all. It seems the build-id is for debugging purposes. Consider disabling it if you don't need it.